### PR TITLE
Formatting changes and "other forms" section

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ fn format_sense(value: &Value, index: usize, prev_parts_of_speech: &mut String) 
         // Do not repeat a meaning's part of speech if it is the same as the previous meaning
         if !parts.is_empty() && parts != *prev_parts_of_speech {
             *prev_parts_of_speech = parts.clone();
-            format!("[{}]\n    ", parts.bright_blue())
+            format!("{}\n    ", parts.bright_blue())
         } else {
             String::new()
         }
@@ -230,12 +230,13 @@ fn format_sense(value: &Value, index: usize, prev_parts_of_speech: &mut String) 
         true
     };
 
+    let index_str = format!("{}.",(index + 1));
     let tags = format_sense_tags(value);
 
     (format!(
-        "{}{}. {} {}",
+        "{}{} {} {}",
         parts_of_speech,
-        (index + 1).to_string().bright_black(),
+        index_str.bright_black(),
         english_definiton
             .iter()
             .map(|i| value_to_str(i))

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,8 +153,7 @@ fn print_item(query: &str, value: &Value, output: &mut String) -> Option<usize> 
     let main_form = japanese.get(0)?;
     let mut num_of_lines = 0;
 
-    let mut aux = format!("{} {}\n", format_form(query, main_form)?, format_result_tags(value));
-    *output += &aux;
+    *output += &format!("{} {}\n", format_form(query, main_form)?, format_result_tags(value));
 
     // Print senses
     let senses = value_to_arr(value.get("senses")?);
@@ -170,8 +169,7 @@ fn print_item(query: &str, value: &Value, output: &mut String) -> Option<usize> 
             num_of_lines += 1;
         }
 
-        aux = format!("    {}\n", sense_str);
-        *output += &aux;
+        *output += &format!("    {}\n", sense_str);
     }
 
     // Print alternative readings and kanji usage
@@ -181,12 +179,10 @@ fn print_item(query: &str, value: &Value, output: &mut String) -> Option<usize> 
 
             *output += &format!("    {}", "Other forms\n".bright_blue());
 
-            aux = format!("    {}", format_form(query, form)?);
-            *output += &aux;
+            *output += &format!("    {}", format_form(query, form)?);
 
             for form in japanese.get(2).iter() {
-                aux = format!(", {}", format_form(query, form)?);
-                *output += &aux;
+                *output += &format!(", {}", format_form(query, form)?);
             }
             output.push('\n');
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,11 +178,10 @@ fn print_item(query: &str, value: &Value, output: &mut String) -> Option<usize> 
             num_of_lines += 2;
 
             *output += &format!("    {}", "Other forms\n".bright_blue());
-
             *output += &format!("    {}", format_form(query, form)?);
 
-            for form in japanese.get(2).iter() {
-                *output += &format!(", {}", format_form(query, form)?);
+            for i in 2..japanese.len() {
+                *output += &format!(", {}", format_form(query, japanese.get(i)?)?);
             }
             output.push('\n');
         }


### PR DESCRIPTION
I did a couple of more changes as I want to use this tool over going to the website as much as I can, and I thought upstream might like them.

In short, I changed the formatting to be more like what you see in jisho and also added other forms when available (e.g. 私たち vs 私達) as these are returned by the API but were unused.

Another thing that I might add later is additional usage info, like how しか is only used with neg. sentences, and pagination for more than one page of results. But I'll annoy you with that some other time.